### PR TITLE
Add distinct to RouteSelect query in order to avoid duplicate results

### DIFF
--- a/find/route_select.go
+++ b/find/route_select.go
@@ -26,6 +26,7 @@ func RouteSelect(limit *int, after *int, ids []int, active bool, where *model.Ro
 		"feed_versions.sha1 AS feed_version_sha1",
 		"tl_route_onestop_ids.onestop_id",
 	).
+		Distinct().
 		From("gtfs_routes").
 		Join("feed_versions ON feed_versions.id = gtfs_routes.feed_version_id").
 		Join("current_feeds ON current_feeds.id = feed_versions.feed_id").


### PR DESCRIPTION
When querying for routes, the results are duplicated, we resolved adding `Distinct` to `RouteSelect` query.

You can replicate the result with the following graphql query.

```
  routes(where: {
    agency_ids: [your_agency], near: {
    lat: 43.793224,
    lon: 11.221117,
    radius: 10,
  }}) {
    id
    geometry
    route_long_name
  }
```


Co-Authored-By: David Costa <david@zarel.net>