### PR TITLE
Add support for lat/lon/radius and bbox to REST operator API

### DIFF
--- a/server/rest/agency_request.go
+++ b/server/rest/agency_request.go
@@ -9,7 +9,7 @@ import (
 //go:embed agency_request.gql
 var agencyQuery string
 
-// AgencyRequest holds options for a Route request
+// AgencyRequest holds options for an Agency request
 type AgencyRequest struct {
 	ID              int       `json:"id,string"`
 	AgencyKey       string    `json:"agency_key"`

--- a/server/rest/feed_request.go
+++ b/server/rest/feed_request.go
@@ -9,7 +9,7 @@ import (
 //go:embed feed_request.gql
 var feedQuery string
 
-// FeedRequest holds options for a Route request
+// FeedRequest holds options for a Feed request
 type FeedRequest struct {
 	FeedKey          string    `json:"feed_key"`
 	ID               int       `json:"id,string"`

--- a/server/rest/feed_version_request.go
+++ b/server/rest/feed_version_request.go
@@ -8,7 +8,7 @@ import (
 //go:embed feed_version_request.gql
 var feedVersionQuery string
 
-// FeedVersionRequest holds options for a Route request
+// FeedVersionRequest holds options for a Feed Version request
 type FeedVersionRequest struct {
 	FeedVersionKey  string    `json:"feed_version_key"`
 	FeedKey         string    `json:"feed_key"`

--- a/server/rest/operator_request.go
+++ b/server/rest/operator_request.go
@@ -8,21 +8,25 @@ import (
 //go:embed operator_request.gql
 var operatorQuery string
 
-// OperatorRequest holds options for a Route request
+// OperatorRequest holds options for an Operator request
 type OperatorRequest struct {
-	OperatorKey   string `json:"operator_key"`
-	ID            int    `json:"id,string"`
-	OnestopID     string `json:"onestop_id"`
-	FeedOnestopID string `json:"feed_onestop_id"`
-	Search        string `json:"search"`
-	TagKey        string `json:"tag_key"`
-	TagValue      string `json:"tag_value"`
-	Adm0Name      string `json:"adm0_name"`
-	Adm0Iso       string `json:"adm0_iso"`
-	Adm1Name      string `json:"adm1_name"`
-	Adm1Iso       string `json:"adm1_iso"`
-	CityName      string `json:"city_name"`
-	IncludeAlerts bool   `json:"include_alerts,string"`
+	OperatorKey   string    `json:"operator_key"`
+	ID            int       `json:"id,string"`
+	OnestopID     string    `json:"onestop_id"`
+	FeedOnestopID string    `json:"feed_onestop_id"`
+	Search        string    `json:"search"`
+	TagKey        string    `json:"tag_key"`
+	TagValue      string    `json:"tag_value"`
+	Lon           float64   `json:"lon,string"`
+	Lat           float64   `json:"lat,string"`
+	Bbox          *restBbox `json:"bbox"`
+	Radius        float64   `json:"radius,string"`
+	Adm0Name      string    `json:"adm0_name"`
+	Adm0Iso       string    `json:"adm0_iso"`
+	Adm1Name      string    `json:"adm1_name"`
+	Adm1Iso       string    `json:"adm1_iso"`
+	CityName      string    `json:"city_name"`
+	IncludeAlerts bool      `json:"include_alerts,string"`
 	LicenseFilter
 	WithCursor
 }
@@ -52,6 +56,12 @@ func (r OperatorRequest) Query() (string, map[string]interface{}) {
 	}
 	if r.TagKey != "" {
 		where["tags"] = hw{r.TagKey: r.TagValue}
+	}
+	if r.Lat != 0.0 && r.Lon != 0.0 {
+		where["near"] = hw{"lat": r.Lat, "lon": r.Lon, "radius": r.Radius}
+	}
+	if r.Bbox != nil {
+		where["bbox"] = r.Bbox.AsJson()
 	}
 	if r.Adm0Name != "" {
 		where["adm0_name"] = r.Adm0Name


### PR DESCRIPTION
These four parameters are documented as supported on https://www.transit.land/documentation/rest-api/agencies#operator-request-parameters, but to my surprise, I got back a very unfiltered list of results when using the `lat`, `lon`, and `radius` parameters. These work on an agency request, but it would be great at the operator level as well.

It looks like the lower-level GraphQL interface supports these parameters, so we just need to make sure they are passed through appropriately, much like the agency request. #174 added the low-level support but didn't put it in the Operator REST request code.