### PR TITLE
Document the `include_stops` parameter on a route request

### DIFF
--- a/docs/openapi/openapi.go
+++ b/docs/openapi/openapi.go
@@ -88,6 +88,22 @@ var gqlScalarToOASchema = map[string]oa.Schema{
 	"Strings": {
 		Type: oa.NewArraySchema().Type,
 	},
+	"Color": {
+		Type: oa.NewStringSchema().Type,
+	},
+	"Language": {
+		Type: oa.NewStringSchema().Type,
+	},
+	"Url": {
+		Type: oa.NewStringSchema().Type,
+	},
+	"Email": {
+		Type:   oa.NewStringSchema().Type,
+		Format: "email",
+	},
+	"Timezone": {
+		Type: oa.NewStringSchema().Type,
+	},
 	"Any":        {},
 	"Upload":     {},
 	"Key":        {},

--- a/docs/openapi/rest.json
+++ b/docs/openapi/rest.json
@@ -465,12 +465,15 @@
                         "properties": {
                           "agency_email": {
                             "description": "GTFS agency.agency_email",
+                            "format": "email",
+                            "nullable": true,
                             "title": "agency_email",
                             "type": "string",
                             "x-order": 20
                           },
                           "agency_fare_url": {
                             "description": "GTFS agency.agency_fare_url",
+                            "nullable": true,
                             "title": "agency_fare_url",
                             "type": "string",
                             "x-order": 18
@@ -483,6 +486,7 @@
                           },
                           "agency_lang": {
                             "description": "GTFS agency.agency_lang",
+                            "nullable": true,
                             "title": "agency_lang",
                             "type": "string",
                             "x-order": 14
@@ -495,6 +499,7 @@
                           },
                           "agency_phone": {
                             "description": "GTFS agency.agency_phone",
+                            "nullable": true,
                             "title": "agency_phone",
                             "type": "string",
                             "x-order": 16
@@ -1142,12 +1147,14 @@
                                 },
                                 "route_long_name": {
                                   "description": "GTFS routes.route_long_name",
+                                  "nullable": true,
                                   "title": "route_long_name",
                                   "type": "string",
                                   "x-order": 118
                                 },
                                 "route_short_name": {
                                   "description": "GTFS routes.route_short_name",
+                                  "nullable": true,
                                   "title": "route_short_name",
                                   "type": "string",
                                   "x-order": 116
@@ -1394,6 +1401,7 @@
                                 },
                                 "feed_contact_email": {
                                   "description": "GTFS feed_info.feed_contact_email",
+                                  "format": "email",
                                   "nullable": true,
                                   "title": "feed_contact_email",
                                   "type": "string",
@@ -2984,6 +2992,9 @@
             ]
           },
           {
+            "$ref": "#/components/parameters/includeAlertsParam"
+          },
+          {
             "description": "Include route geometry",
             "in": "query",
             "name": "include_geometry",
@@ -3002,10 +3013,25 @@
             ]
           },
           {
-            "$ref": "#/components/parameters/idParam"
+            "description": "Include route stops",
+            "in": "query",
+            "name": "include_stops",
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "x-example-requests": [
+              {
+                "description": "include_stops=true",
+                "url": "include_stops=true"
+              }
+            ]
           },
           {
-            "$ref": "#/components/parameters/includeAlertsParam"
+            "$ref": "#/components/parameters/idParam"
           },
           {
             "$ref": "#/components/parameters/afterParam"
@@ -3656,12 +3682,14 @@
                           },
                           "route_color": {
                             "description": "GTFS routes.route_color",
+                            "nullable": true,
                             "title": "route_color",
                             "type": "string",
                             "x-order": 4
                           },
                           "route_desc": {
                             "description": "GTFS routes.route_desc",
+                            "nullable": true,
                             "title": "route_desc",
                             "type": "string",
                             "x-order": 6
@@ -3674,18 +3702,21 @@
                           },
                           "route_long_name": {
                             "description": "GTFS routes.route_long_name",
+                            "nullable": true,
                             "title": "route_long_name",
                             "type": "string",
                             "x-order": 10
                           },
                           "route_short_name": {
                             "description": "GTFS routes.route_short_name",
+                            "nullable": true,
                             "title": "route_short_name",
                             "type": "string",
                             "x-order": 12
                           },
                           "route_sort_order": {
                             "description": "GTFS routes.route_sort_order",
+                            "nullable": true,
                             "title": "route_sort_order",
                             "type": "integer",
                             "x-order": 14
@@ -3929,6 +3960,7 @@
                                     "stop_name": {
                                       "description": "GTFS stops.stop_name",
                                       "example": "MADISON AV/E 68 ST",
+                                      "nullable": true,
                                       "title": "stop_name",
                                       "type": "string",
                                       "x-order": 150
@@ -3951,6 +3983,7 @@
                           },
                           "route_text_color": {
                             "description": "GTFS routes.route_text_color",
+                            "nullable": true,
                             "title": "route_text_color",
                             "type": "string",
                             "x-order": 16
@@ -3963,6 +3996,7 @@
                           },
                           "route_url": {
                             "description": "GTFS routes.route_url",
+                            "nullable": true,
                             "title": "route_url",
                             "type": "string",
                             "x-order": 20
@@ -4381,12 +4415,14 @@
                           },
                           "bikes_allowed": {
                             "description": "GTFS trips.bikes_allowed",
+                            "nullable": true,
                             "title": "bikes_allowed",
                             "type": "integer",
                             "x-order": 16
                           },
                           "block_id": {
                             "description": "GTFS trips.block_id",
+                            "nullable": true,
                             "title": "block_id",
                             "type": "string",
                             "x-order": 12
@@ -4490,6 +4526,7 @@
                           },
                           "direction_id": {
                             "description": "GTFS trips.direction_id",
+                            "nullable": true,
                             "title": "direction_id",
                             "type": "integer",
                             "x-order": 10
@@ -4553,6 +4590,7 @@
                                 },
                                 "exact_times": {
                                   "description": "GTFS frequencies.exact_times",
+                                  "nullable": true,
                                   "title": "exact_times",
                                   "type": "integer",
                                   "x-order": 75
@@ -5066,12 +5104,14 @@
                               },
                               "route_long_name": {
                                 "description": "GTFS routes.route_long_name",
+                                "nullable": true,
                                 "title": "route_long_name",
                                 "type": "string",
                                 "x-order": 132
                               },
                               "route_short_name": {
                                 "description": "GTFS routes.route_short_name",
+                                "nullable": true,
                                 "title": "route_short_name",
                                 "type": "string",
                                 "x-order": 130
@@ -5083,7 +5123,7 @@
                             "x-order": 233
                           },
                           "schedule_relationship": {
-                            "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                            "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                             "enum": [
                               "SCHEDULED",
                               "ADDED",
@@ -5143,6 +5183,7 @@
                                   "description": "GTFS stop_times.arrival_time",
                                   "example": "15:21:04",
                                   "format": "hms",
+                                  "nullable": true,
                                   "title": "arrival_time",
                                   "type": "string",
                                   "x-order": 236
@@ -5151,6 +5192,7 @@
                                   "description": "GTFS stop_times.departure_time",
                                   "example": "15:21:04",
                                   "format": "hms",
+                                  "nullable": true,
                                   "title": "departure_time",
                                   "type": "string",
                                   "x-order": 238
@@ -5411,6 +5453,7 @@
                                     "stop_name": {
                                       "description": "GTFS stops.stop_name",
                                       "example": "MADISON AV/E 68 ST",
+                                      "nullable": true,
                                       "title": "stop_name",
                                       "type": "string",
                                       "x-order": 257
@@ -5453,6 +5496,7 @@
                           },
                           "trip_headsign": {
                             "description": "GTFS trips.trip_headsign",
+                            "nullable": true,
                             "title": "trip_headsign",
                             "type": "string",
                             "x-order": 6
@@ -5465,12 +5509,14 @@
                           },
                           "trip_short_name": {
                             "description": "GTFS trips.trip_short_name",
+                            "nullable": true,
                             "title": "trip_short_name",
                             "type": "string",
                             "x-order": 8
                           },
                           "wheelchair_accessible": {
                             "description": "GTFS trips.wheelchair_accessible",
+                            "nullable": true,
                             "title": "wheelchair_accessible",
                             "type": "integer",
                             "x-order": 14
@@ -5985,6 +6031,7 @@
                               },
                               "level_name": {
                                 "description": "GTFS levels.level_name",
+                                "nullable": true,
                                 "title": "level_name",
                                 "type": "string",
                                 "x-order": 57
@@ -5996,7 +6043,7 @@
                             "x-order": 60
                           },
                           "location_type": {
-                            "description": "GTFS stops.location_type",
+                            "description": "GTFS stops.location_type; this is optional in GTFS spec",
                             "enum": [
                               "0",
                               "1",
@@ -6251,6 +6298,7 @@
                               "stop_name": {
                                 "description": "GTFS stops.stop_name",
                                 "example": "MADISON AV/E 68 ST",
+                                "nullable": true,
                                 "title": "stop_name",
                                 "type": "string",
                                 "x-order": 67
@@ -6308,6 +6356,7 @@
                           },
                           "stop_code": {
                             "description": "GTFS stops.stop_code",
+                            "nullable": true,
                             "title": "stop_code",
                             "type": "string",
                             "x-order": 14
@@ -6315,6 +6364,7 @@
                           "stop_desc": {
                             "description": "GTFS stops.stop_desc",
                             "example": "NW Corner of Broadway and 14th",
+                            "nullable": true,
                             "title": "stop_desc",
                             "type": "string",
                             "x-order": 12
@@ -6329,6 +6379,7 @@
                           "stop_name": {
                             "description": "GTFS stops.stop_name",
                             "example": "MADISON AV/E 68 ST",
+                            "nullable": true,
                             "title": "stop_name",
                             "type": "string",
                             "x-order": 6
@@ -6336,12 +6387,14 @@
                           "stop_timezone": {
                             "description": "GTFS stops.stop_timezone; if overriding agency/route timezone",
                             "example": "America/Los_Angeles",
+                            "nullable": true,
                             "title": "stop_timezone",
                             "type": "string",
                             "x-order": 10
                           },
                           "stop_url": {
                             "description": "GTFS stops.stop_url",
+                            "nullable": true,
                             "title": "stop_url",
                             "type": "string",
                             "x-order": 8
@@ -6360,12 +6413,14 @@
                               "1",
                               "2"
                             ],
+                            "nullable": true,
                             "title": "wheelchair_boarding",
                             "type": "integer",
                             "x-order": 22
                           },
                           "zone_id": {
                             "description": "GTFS stops.zone_id",
+                            "nullable": true,
                             "title": "zone_id",
                             "type": "string",
                             "x-order": 16
@@ -7006,7 +7061,7 @@
                                         "description": "Detailed arrival information, including GTFS-RT updates and estimates",
                                         "properties": {
                                           "delay": {
-                                            "description": "Estimated delay, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                            "description": "Estimated schedule delay, in seconds. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See GTFS Realtime documentation. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                             "nullable": true,
                                             "title": "delay",
                                             "type": "integer",
@@ -7022,7 +7077,7 @@
                                             "x-order": 407
                                           },
                                           "estimated_delay": {
-                                            "description": "Estimated delay, based on a matching TripUpdate or previous StopTimeUpdate in this trip",
+                                            "description": "Estimated schedule delay, in seconds, based on either a timestamp or overall trip delay.\n\nThis value can be set directly from a matching GTFS-RT StopTimeUpdate timestamp or delay value or set via an estimated overall trip delay. The value is capped at +/- 86,400 seconds (24 hours). Values larger than that are are likely erroneous and will be set to null.",
                                             "nullable": true,
                                             "title": "estimated_delay",
                                             "type": "integer",
@@ -7074,7 +7129,7 @@
                                             "x-order": 403
                                           },
                                           "uncertainty": {
-                                            "description": "Estimated uncertainty, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                            "description": "Estimation uncertainty. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                             "nullable": true,
                                             "title": "uncertainty",
                                             "type": "integer",
@@ -7090,6 +7145,7 @@
                                         "description": "GTFS stop_times.arrival_time",
                                         "example": "15:21:04",
                                         "format": "hms",
+                                        "nullable": true,
                                         "title": "arrival_time",
                                         "type": "string",
                                         "x-order": 388
@@ -7121,7 +7177,7 @@
                                         "description": "Detailed departure information, including GTFS-RT updates and estimates",
                                         "properties": {
                                           "delay": {
-                                            "description": "Estimated delay, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                            "description": "Estimated schedule delay, in seconds. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See GTFS Realtime documentation. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                             "nullable": true,
                                             "title": "delay",
                                             "type": "integer",
@@ -7137,7 +7193,7 @@
                                             "x-order": 427
                                           },
                                           "estimated_delay": {
-                                            "description": "Estimated delay, based on a matching TripUpdate or previous StopTimeUpdate in this trip",
+                                            "description": "Estimated schedule delay, in seconds, based on either a timestamp or overall trip delay.\n\nThis value can be set directly from a matching GTFS-RT StopTimeUpdate timestamp or delay value or set via an estimated overall trip delay. The value is capped at +/- 86,400 seconds (24 hours). Values larger than that are are likely erroneous and will be set to null.",
                                             "nullable": true,
                                             "title": "estimated_delay",
                                             "type": "integer",
@@ -7189,7 +7245,7 @@
                                             "x-order": 423
                                           },
                                           "uncertainty": {
-                                            "description": "Estimated uncertainty, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                            "description": "Estimation uncertainty. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                             "nullable": true,
                                             "title": "uncertainty",
                                             "type": "integer",
@@ -7205,6 +7261,7 @@
                                         "description": "GTFS stop_times.departure_time",
                                         "example": "15:21:04",
                                         "format": "hms",
+                                        "nullable": true,
                                         "title": "departure_time",
                                         "type": "string",
                                         "x-order": 390
@@ -7231,7 +7288,7 @@
                                         "x-order": 376
                                       },
                                       "schedule_relationship": {
-                                        "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                                        "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                                         "enum": [
                                           "SCHEDULED",
                                           "ADDED",
@@ -7502,18 +7559,21 @@
                                           },
                                           "bikes_allowed": {
                                             "description": "GTFS trips.bikes_allowed",
+                                            "nullable": true,
                                             "title": "bikes_allowed",
                                             "type": "integer",
                                             "x-order": 456
                                           },
                                           "block_id": {
                                             "description": "GTFS trips.block_id",
+                                            "nullable": true,
                                             "title": "block_id",
                                             "type": "string",
                                             "x-order": 452
                                           },
                                           "direction_id": {
                                             "description": "GTFS trips.direction_id",
+                                            "nullable": true,
                                             "title": "direction_id",
                                             "type": "integer",
                                             "x-order": 450
@@ -7532,6 +7592,7 @@
                                                 },
                                                 "exact_times": {
                                                   "description": "GTFS frequencies.exact_times",
+                                                  "nullable": true,
                                                   "title": "exact_times",
                                                   "type": "integer",
                                                   "x-order": 611
@@ -8059,12 +8120,14 @@
                                               },
                                               "route_color": {
                                                 "description": "GTFS routes.route_color",
+                                                "nullable": true,
                                                 "title": "route_color",
                                                 "type": "string",
                                                 "x-order": 476
                                               },
                                               "route_desc": {
                                                 "description": "GTFS routes.route_desc",
+                                                "nullable": true,
                                                 "title": "route_desc",
                                                 "type": "string",
                                                 "x-order": 478
@@ -8077,18 +8140,21 @@
                                               },
                                               "route_long_name": {
                                                 "description": "GTFS routes.route_long_name",
+                                                "nullable": true,
                                                 "title": "route_long_name",
                                                 "type": "string",
                                                 "x-order": 474
                                               },
                                               "route_short_name": {
                                                 "description": "GTFS routes.route_short_name",
+                                                "nullable": true,
                                                 "title": "route_short_name",
                                                 "type": "string",
                                                 "x-order": 472
                                               },
                                               "route_text_color": {
                                                 "description": "GTFS routes.route_text_color",
+                                                "nullable": true,
                                                 "title": "route_text_color",
                                                 "type": "string",
                                                 "x-order": 480
@@ -8101,6 +8167,7 @@
                                               },
                                               "route_url": {
                                                 "description": "GTFS routes.route_url",
+                                                "nullable": true,
                                                 "title": "route_url",
                                                 "type": "string",
                                                 "x-order": 484
@@ -8112,7 +8179,7 @@
                                             "x-order": 590
                                           },
                                           "schedule_relationship": {
-                                            "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                                            "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                                             "enum": [
                                               "SCHEDULED",
                                               "ADDED",
@@ -8181,6 +8248,7 @@
                                           },
                                           "trip_headsign": {
                                             "description": "GTFS trips.trip_headsign",
+                                            "nullable": true,
                                             "title": "trip_headsign",
                                             "type": "string",
                                             "x-order": 446
@@ -8193,12 +8261,14 @@
                                           },
                                           "trip_short_name": {
                                             "description": "GTFS trips.trip_short_name",
+                                            "nullable": true,
                                             "title": "trip_short_name",
                                             "type": "string",
                                             "x-order": 448
                                           },
                                           "wheelchair_accessible": {
                                             "description": "GTFS trips.wheelchair_accessible",
+                                            "nullable": true,
                                             "title": "wheelchair_accessible",
                                             "type": "integer",
                                             "x-order": 454
@@ -8231,7 +8301,7 @@
                                   "x-order": 340
                                 },
                                 "location_type": {
-                                  "description": "GTFS stops.location_type",
+                                  "description": "GTFS stops.location_type; this is optional in GTFS spec",
                                   "enum": [
                                     "0",
                                     "1",
@@ -8259,6 +8329,7 @@
                                 },
                                 "stop_code": {
                                   "description": "GTFS stops.stop_code",
+                                  "nullable": true,
                                   "title": "stop_code",
                                   "type": "string",
                                   "x-order": 344
@@ -8266,6 +8337,7 @@
                                 "stop_desc": {
                                   "description": "GTFS stops.stop_desc",
                                   "example": "NW Corner of Broadway and 14th",
+                                  "nullable": true,
                                   "title": "stop_desc",
                                   "type": "string",
                                   "x-order": 346
@@ -8280,6 +8352,7 @@
                                 "stop_name": {
                                   "description": "GTFS stops.stop_name",
                                   "example": "MADISON AV/E 68 ST",
+                                  "nullable": true,
                                   "title": "stop_name",
                                   "type": "string",
                                   "x-order": 350
@@ -8287,12 +8360,14 @@
                                 "stop_timezone": {
                                   "description": "GTFS stops.stop_timezone; if overriding agency/route timezone",
                                   "example": "America/Los_Angeles",
+                                  "nullable": true,
                                   "title": "stop_timezone",
                                   "type": "string",
                                   "x-order": 352
                                 },
                                 "stop_url": {
                                   "description": "GTFS stops.stop_url",
+                                  "nullable": true,
                                   "title": "stop_url",
                                   "type": "string",
                                   "x-order": 354
@@ -8311,12 +8386,14 @@
                                     "1",
                                     "2"
                                   ],
+                                  "nullable": true,
                                   "title": "wheelchair_boarding",
                                   "type": "integer",
                                   "x-order": 364
                                 },
                                 "zone_id": {
                                   "description": "GTFS stops.zone_id",
+                                  "nullable": true,
                                   "title": "zone_id",
                                   "type": "string",
                                   "x-order": 366
@@ -8340,7 +8417,7 @@
                                   "description": "Detailed arrival information, including GTFS-RT updates and estimates",
                                   "properties": {
                                     "delay": {
-                                      "description": "Estimated delay, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                      "description": "Estimated schedule delay, in seconds. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See GTFS Realtime documentation. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                       "nullable": true,
                                       "title": "delay",
                                       "type": "integer",
@@ -8356,7 +8433,7 @@
                                       "x-order": 84
                                     },
                                     "estimated_delay": {
-                                      "description": "Estimated delay, based on a matching TripUpdate or previous StopTimeUpdate in this trip",
+                                      "description": "Estimated schedule delay, in seconds, based on either a timestamp or overall trip delay.\n\nThis value can be set directly from a matching GTFS-RT StopTimeUpdate timestamp or delay value or set via an estimated overall trip delay. The value is capped at +/- 86,400 seconds (24 hours). Values larger than that are are likely erroneous and will be set to null.",
                                       "nullable": true,
                                       "title": "estimated_delay",
                                       "type": "integer",
@@ -8408,7 +8485,7 @@
                                       "x-order": 80
                                     },
                                     "uncertainty": {
-                                      "description": "Estimated uncertainty, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                      "description": "Estimation uncertainty. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                       "nullable": true,
                                       "title": "uncertainty",
                                       "type": "integer",
@@ -8424,6 +8501,7 @@
                                   "description": "GTFS stop_times.arrival_time",
                                   "example": "15:21:04",
                                   "format": "hms",
+                                  "nullable": true,
                                   "title": "arrival_time",
                                   "type": "string",
                                   "x-order": 65
@@ -8455,7 +8533,7 @@
                                   "description": "Detailed departure information, including GTFS-RT updates and estimates",
                                   "properties": {
                                     "delay": {
-                                      "description": "Estimated delay, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                      "description": "Estimated schedule delay, in seconds. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See GTFS Realtime documentation. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                       "nullable": true,
                                       "title": "delay",
                                       "type": "integer",
@@ -8471,7 +8549,7 @@
                                       "x-order": 104
                                     },
                                     "estimated_delay": {
-                                      "description": "Estimated delay, based on a matching TripUpdate or previous StopTimeUpdate in this trip",
+                                      "description": "Estimated schedule delay, in seconds, based on either a timestamp or overall trip delay.\n\nThis value can be set directly from a matching GTFS-RT StopTimeUpdate timestamp or delay value or set via an estimated overall trip delay. The value is capped at +/- 86,400 seconds (24 hours). Values larger than that are are likely erroneous and will be set to null.",
                                       "nullable": true,
                                       "title": "estimated_delay",
                                       "type": "integer",
@@ -8523,7 +8601,7 @@
                                       "x-order": 100
                                     },
                                     "uncertainty": {
-                                      "description": "Estimated uncertainty, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                      "description": "Estimation uncertainty. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                       "nullable": true,
                                       "title": "uncertainty",
                                       "type": "integer",
@@ -8539,6 +8617,7 @@
                                   "description": "GTFS stop_times.departure_time",
                                   "example": "15:21:04",
                                   "format": "hms",
+                                  "nullable": true,
                                   "title": "departure_time",
                                   "type": "string",
                                   "x-order": 67
@@ -8565,7 +8644,7 @@
                                   "x-order": 53
                                 },
                                 "schedule_relationship": {
-                                  "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                                  "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                                   "enum": [
                                     "SCHEDULED",
                                     "ADDED",
@@ -8836,18 +8915,21 @@
                                     },
                                     "bikes_allowed": {
                                       "description": "GTFS trips.bikes_allowed",
+                                      "nullable": true,
                                       "title": "bikes_allowed",
                                       "type": "integer",
                                       "x-order": 133
                                     },
                                     "block_id": {
                                       "description": "GTFS trips.block_id",
+                                      "nullable": true,
                                       "title": "block_id",
                                       "type": "string",
                                       "x-order": 129
                                     },
                                     "direction_id": {
                                       "description": "GTFS trips.direction_id",
+                                      "nullable": true,
                                       "title": "direction_id",
                                       "type": "integer",
                                       "x-order": 127
@@ -8866,6 +8948,7 @@
                                           },
                                           "exact_times": {
                                             "description": "GTFS frequencies.exact_times",
+                                            "nullable": true,
                                             "title": "exact_times",
                                             "type": "integer",
                                             "x-order": 288
@@ -9393,12 +9476,14 @@
                                         },
                                         "route_color": {
                                           "description": "GTFS routes.route_color",
+                                          "nullable": true,
                                           "title": "route_color",
                                           "type": "string",
                                           "x-order": 153
                                         },
                                         "route_desc": {
                                           "description": "GTFS routes.route_desc",
+                                          "nullable": true,
                                           "title": "route_desc",
                                           "type": "string",
                                           "x-order": 155
@@ -9411,18 +9496,21 @@
                                         },
                                         "route_long_name": {
                                           "description": "GTFS routes.route_long_name",
+                                          "nullable": true,
                                           "title": "route_long_name",
                                           "type": "string",
                                           "x-order": 151
                                         },
                                         "route_short_name": {
                                           "description": "GTFS routes.route_short_name",
+                                          "nullable": true,
                                           "title": "route_short_name",
                                           "type": "string",
                                           "x-order": 149
                                         },
                                         "route_text_color": {
                                           "description": "GTFS routes.route_text_color",
+                                          "nullable": true,
                                           "title": "route_text_color",
                                           "type": "string",
                                           "x-order": 157
@@ -9435,6 +9523,7 @@
                                         },
                                         "route_url": {
                                           "description": "GTFS routes.route_url",
+                                          "nullable": true,
                                           "title": "route_url",
                                           "type": "string",
                                           "x-order": 161
@@ -9446,7 +9535,7 @@
                                       "x-order": 267
                                     },
                                     "schedule_relationship": {
-                                      "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                                      "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                                       "enum": [
                                         "SCHEDULED",
                                         "ADDED",
@@ -9515,6 +9604,7 @@
                                     },
                                     "trip_headsign": {
                                       "description": "GTFS trips.trip_headsign",
+                                      "nullable": true,
                                       "title": "trip_headsign",
                                       "type": "string",
                                       "x-order": 123
@@ -9527,12 +9617,14 @@
                                     },
                                     "trip_short_name": {
                                       "description": "GTFS trips.trip_short_name",
+                                      "nullable": true,
                                       "title": "trip_short_name",
                                       "type": "string",
                                       "x-order": 125
                                     },
                                     "wheelchair_accessible": {
                                       "description": "GTFS trips.wheelchair_accessible",
+                                      "nullable": true,
                                       "title": "wheelchair_accessible",
                                       "type": "integer",
                                       "x-order": 131
@@ -9616,7 +9708,7 @@
                             "x-order": 3
                           },
                           "location_type": {
-                            "description": "GTFS stops.location_type",
+                            "description": "GTFS stops.location_type; this is optional in GTFS spec",
                             "enum": [
                               "0",
                               "1",
@@ -10073,7 +10165,7 @@
                                             "description": "Detailed arrival information, including GTFS-RT updates and estimates",
                                             "properties": {
                                               "delay": {
-                                                "description": "Estimated delay, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                                "description": "Estimated schedule delay, in seconds. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See GTFS Realtime documentation. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                                 "nullable": true,
                                                 "title": "delay",
                                                 "type": "integer",
@@ -10089,7 +10181,7 @@
                                                 "x-order": 806
                                               },
                                               "estimated_delay": {
-                                                "description": "Estimated delay, based on a matching TripUpdate or previous StopTimeUpdate in this trip",
+                                                "description": "Estimated schedule delay, in seconds, based on either a timestamp or overall trip delay.\n\nThis value can be set directly from a matching GTFS-RT StopTimeUpdate timestamp or delay value or set via an estimated overall trip delay. The value is capped at +/- 86,400 seconds (24 hours). Values larger than that are are likely erroneous and will be set to null.",
                                                 "nullable": true,
                                                 "title": "estimated_delay",
                                                 "type": "integer",
@@ -10141,7 +10233,7 @@
                                                 "x-order": 802
                                               },
                                               "uncertainty": {
-                                                "description": "Estimated uncertainty, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                                "description": "Estimation uncertainty. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                                 "nullable": true,
                                                 "title": "uncertainty",
                                                 "type": "integer",
@@ -10157,6 +10249,7 @@
                                             "description": "GTFS stop_times.arrival_time",
                                             "example": "15:21:04",
                                             "format": "hms",
+                                            "nullable": true,
                                             "title": "arrival_time",
                                             "type": "string",
                                             "x-order": 787
@@ -10188,7 +10281,7 @@
                                             "description": "Detailed departure information, including GTFS-RT updates and estimates",
                                             "properties": {
                                               "delay": {
-                                                "description": "Estimated delay, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                                "description": "Estimated schedule delay, in seconds. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See GTFS Realtime documentation. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                                 "nullable": true,
                                                 "title": "delay",
                                                 "type": "integer",
@@ -10204,7 +10297,7 @@
                                                 "x-order": 826
                                               },
                                               "estimated_delay": {
-                                                "description": "Estimated delay, based on a matching TripUpdate or previous StopTimeUpdate in this trip",
+                                                "description": "Estimated schedule delay, in seconds, based on either a timestamp or overall trip delay.\n\nThis value can be set directly from a matching GTFS-RT StopTimeUpdate timestamp or delay value or set via an estimated overall trip delay. The value is capped at +/- 86,400 seconds (24 hours). Values larger than that are are likely erroneous and will be set to null.",
                                                 "nullable": true,
                                                 "title": "estimated_delay",
                                                 "type": "integer",
@@ -10256,7 +10349,7 @@
                                                 "x-order": 822
                                               },
                                               "uncertainty": {
-                                                "description": "Estimated uncertainty, source directly from matching GTFS-RT StopTimeUpdate. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
+                                                "description": "Estimation uncertainty. This value is set when there is a directly matching GTFS-RT StopTimeUpdate for this stop and passed through as-is. See https://gtfs.org/realtime/reference/#message-stoptimeevent",
                                                 "nullable": true,
                                                 "title": "uncertainty",
                                                 "type": "integer",
@@ -10272,6 +10365,7 @@
                                             "description": "GTFS stop_times.departure_time",
                                             "example": "15:21:04",
                                             "format": "hms",
+                                            "nullable": true,
                                             "title": "departure_time",
                                             "type": "string",
                                             "x-order": 789
@@ -10298,7 +10392,7 @@
                                             "x-order": 775
                                           },
                                           "schedule_relationship": {
-                                            "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                                            "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                                             "enum": [
                                               "SCHEDULED",
                                               "ADDED",
@@ -10569,18 +10663,21 @@
                                               },
                                               "bikes_allowed": {
                                                 "description": "GTFS trips.bikes_allowed",
+                                                "nullable": true,
                                                 "title": "bikes_allowed",
                                                 "type": "integer",
                                                 "x-order": 855
                                               },
                                               "block_id": {
                                                 "description": "GTFS trips.block_id",
+                                                "nullable": true,
                                                 "title": "block_id",
                                                 "type": "string",
                                                 "x-order": 851
                                               },
                                               "direction_id": {
                                                 "description": "GTFS trips.direction_id",
+                                                "nullable": true,
                                                 "title": "direction_id",
                                                 "type": "integer",
                                                 "x-order": 849
@@ -10599,6 +10696,7 @@
                                                     },
                                                     "exact_times": {
                                                       "description": "GTFS frequencies.exact_times",
+                                                      "nullable": true,
                                                       "title": "exact_times",
                                                       "type": "integer",
                                                       "x-order": 1010
@@ -11126,12 +11224,14 @@
                                                   },
                                                   "route_color": {
                                                     "description": "GTFS routes.route_color",
+                                                    "nullable": true,
                                                     "title": "route_color",
                                                     "type": "string",
                                                     "x-order": 875
                                                   },
                                                   "route_desc": {
                                                     "description": "GTFS routes.route_desc",
+                                                    "nullable": true,
                                                     "title": "route_desc",
                                                     "type": "string",
                                                     "x-order": 877
@@ -11144,18 +11244,21 @@
                                                   },
                                                   "route_long_name": {
                                                     "description": "GTFS routes.route_long_name",
+                                                    "nullable": true,
                                                     "title": "route_long_name",
                                                     "type": "string",
                                                     "x-order": 873
                                                   },
                                                   "route_short_name": {
                                                     "description": "GTFS routes.route_short_name",
+                                                    "nullable": true,
                                                     "title": "route_short_name",
                                                     "type": "string",
                                                     "x-order": 871
                                                   },
                                                   "route_text_color": {
                                                     "description": "GTFS routes.route_text_color",
+                                                    "nullable": true,
                                                     "title": "route_text_color",
                                                     "type": "string",
                                                     "x-order": 879
@@ -11168,6 +11271,7 @@
                                                   },
                                                   "route_url": {
                                                     "description": "GTFS routes.route_url",
+                                                    "nullable": true,
                                                     "title": "route_url",
                                                     "type": "string",
                                                     "x-order": 883
@@ -11179,7 +11283,7 @@
                                                 "x-order": 989
                                               },
                                               "schedule_relationship": {
-                                                "description": "A status flag for real-time information about this trip. \n  \n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
+                                                "description": "A status flag for real-time information about this trip.\n\n  If no real-time information is available, the value will be STATIC and the estimated arrival/departure times will be empty. A trip with real-time information available will be SCHEDULED; a canceled trip will be CANCELED, and an added trip that is not present in the static GTFS will be ADDED.",
                                                 "enum": [
                                                   "SCHEDULED",
                                                   "ADDED",
@@ -11248,6 +11352,7 @@
                                               },
                                               "trip_headsign": {
                                                 "description": "GTFS trips.trip_headsign",
+                                                "nullable": true,
                                                 "title": "trip_headsign",
                                                 "type": "string",
                                                 "x-order": 845
@@ -11260,12 +11365,14 @@
                                               },
                                               "trip_short_name": {
                                                 "description": "GTFS trips.trip_short_name",
+                                                "nullable": true,
                                                 "title": "trip_short_name",
                                                 "type": "string",
                                                 "x-order": 847
                                               },
                                               "wheelchair_accessible": {
                                                 "description": "GTFS trips.wheelchair_accessible",
+                                                "nullable": true,
                                                 "title": "wheelchair_accessible",
                                                 "type": "integer",
                                                 "x-order": 853
@@ -11298,7 +11405,7 @@
                                       "x-order": 739
                                     },
                                     "location_type": {
-                                      "description": "GTFS stops.location_type",
+                                      "description": "GTFS stops.location_type; this is optional in GTFS spec",
                                       "enum": [
                                         "0",
                                         "1",
@@ -11326,6 +11433,7 @@
                                     },
                                     "stop_code": {
                                       "description": "GTFS stops.stop_code",
+                                      "nullable": true,
                                       "title": "stop_code",
                                       "type": "string",
                                       "x-order": 743
@@ -11333,6 +11441,7 @@
                                     "stop_desc": {
                                       "description": "GTFS stops.stop_desc",
                                       "example": "NW Corner of Broadway and 14th",
+                                      "nullable": true,
                                       "title": "stop_desc",
                                       "type": "string",
                                       "x-order": 745
@@ -11347,6 +11456,7 @@
                                     "stop_name": {
                                       "description": "GTFS stops.stop_name",
                                       "example": "MADISON AV/E 68 ST",
+                                      "nullable": true,
                                       "title": "stop_name",
                                       "type": "string",
                                       "x-order": 749
@@ -11354,12 +11464,14 @@
                                     "stop_timezone": {
                                       "description": "GTFS stops.stop_timezone; if overriding agency/route timezone",
                                       "example": "America/Los_Angeles",
+                                      "nullable": true,
                                       "title": "stop_timezone",
                                       "type": "string",
                                       "x-order": 751
                                     },
                                     "stop_url": {
                                       "description": "GTFS stops.stop_url",
+                                      "nullable": true,
                                       "title": "stop_url",
                                       "type": "string",
                                       "x-order": 753
@@ -11378,12 +11490,14 @@
                                         "1",
                                         "2"
                                       ],
+                                      "nullable": true,
                                       "title": "wheelchair_boarding",
                                       "type": "integer",
                                       "x-order": 763
                                     },
                                     "zone_id": {
                                       "description": "GTFS stops.zone_id",
+                                      "nullable": true,
                                       "title": "zone_id",
                                       "type": "string",
                                       "x-order": 765
@@ -11411,7 +11525,7 @@
                                 "x-order": 709
                               },
                               "location_type": {
-                                "description": "GTFS stops.location_type",
+                                "description": "GTFS stops.location_type; this is optional in GTFS spec",
                                 "enum": [
                                   "0",
                                   "1",
@@ -11439,6 +11553,7 @@
                               },
                               "stop_code": {
                                 "description": "GTFS stops.stop_code",
+                                "nullable": true,
                                 "title": "stop_code",
                                 "type": "string",
                                 "x-order": 713
@@ -11446,6 +11561,7 @@
                               "stop_desc": {
                                 "description": "GTFS stops.stop_desc",
                                 "example": "NW Corner of Broadway and 14th",
+                                "nullable": true,
                                 "title": "stop_desc",
                                 "type": "string",
                                 "x-order": 715
@@ -11460,6 +11576,7 @@
                               "stop_name": {
                                 "description": "GTFS stops.stop_name",
                                 "example": "MADISON AV/E 68 ST",
+                                "nullable": true,
                                 "title": "stop_name",
                                 "type": "string",
                                 "x-order": 719
@@ -11467,12 +11584,14 @@
                               "stop_timezone": {
                                 "description": "GTFS stops.stop_timezone; if overriding agency/route timezone",
                                 "example": "America/Los_Angeles",
+                                "nullable": true,
                                 "title": "stop_timezone",
                                 "type": "string",
                                 "x-order": 721
                               },
                               "stop_url": {
                                 "description": "GTFS stops.stop_url",
+                                "nullable": true,
                                 "title": "stop_url",
                                 "type": "string",
                                 "x-order": 723
@@ -11491,12 +11610,14 @@
                                   "1",
                                   "2"
                                 ],
+                                "nullable": true,
                                 "title": "wheelchair_boarding",
                                 "type": "integer",
                                 "x-order": 733
                               },
                               "zone_id": {
                                 "description": "GTFS stops.zone_id",
+                                "nullable": true,
                                 "title": "zone_id",
                                 "type": "string",
                                 "x-order": 735
@@ -11516,6 +11637,7 @@
                           },
                           "stop_code": {
                             "description": "GTFS stops.stop_code",
+                            "nullable": true,
                             "title": "stop_code",
                             "type": "string",
                             "x-order": 7
@@ -11523,6 +11645,7 @@
                           "stop_desc": {
                             "description": "GTFS stops.stop_desc",
                             "example": "NW Corner of Broadway and 14th",
+                            "nullable": true,
                             "title": "stop_desc",
                             "type": "string",
                             "x-order": 9
@@ -11537,6 +11660,7 @@
                           "stop_name": {
                             "description": "GTFS stops.stop_name",
                             "example": "MADISON AV/E 68 ST",
+                            "nullable": true,
                             "title": "stop_name",
                             "type": "string",
                             "x-order": 13
@@ -11544,12 +11668,14 @@
                           "stop_timezone": {
                             "description": "GTFS stops.stop_timezone; if overriding agency/route timezone",
                             "example": "America/Los_Angeles",
+                            "nullable": true,
                             "title": "stop_timezone",
                             "type": "string",
                             "x-order": 15
                           },
                           "stop_url": {
                             "description": "GTFS stops.stop_url",
+                            "nullable": true,
                             "title": "stop_url",
                             "type": "string",
                             "x-order": 17
@@ -11568,12 +11694,14 @@
                               "1",
                               "2"
                             ],
+                            "nullable": true,
                             "title": "wheelchair_boarding",
                             "type": "integer",
                             "x-order": 27
                           },
                           "zone_id": {
                             "description": "GTFS stops.zone_id",
+                            "nullable": true,
                             "title": "zone_id",
                             "type": "string",
                             "x-order": 29

--- a/server/rest/route_request.go
+++ b/server/rest/route_request.go
@@ -93,6 +93,7 @@ func (r RouteRequest) RequestInfo() RequestInfo {
 						Schema:      newSRVal("string", "", nil),
 						Extensions:  newExt("", "operator_onestop_id=...", "operator_onestop_id=o-9q9-caltrain"),
 					}},
+					newPRef("includeAlertsParam"),
 					&pref{Value: &param{
 						Name:        "include_geometry",
 						In:          "query",
@@ -100,8 +101,14 @@ func (r RouteRequest) RequestInfo() RequestInfo {
 						Schema:      newSRVal("string", "", []any{"true", "false"}),
 						Extensions:  newExt("", "include_geometry=true", ""),
 					}},
+					&pref{Value: &param{
+						Name:        "include_stops",
+						In:          "query",
+						Description: `Include route stops`,
+						Schema:      newSRVal("string", "", []any{"true", "false"}),
+						Extensions:  newExt("", "include_stops=true", ""),
+					}},
 					newPRef("idParam"),
-					newPRef("includeAlertsParam"),
 					newPRef("afterParam"),
 					newPRefExt("limitParam", "", "limit=1", ""),
 					newPRefExt("formatParam", "", "format=png", "?format=png&feed_onestop_id=f-dr5r7-nycdotsiferry"),


### PR DESCRIPTION
This currently works as expected, but is undocumented. I sorted the three `include_*` parameters in alpha order.