### PR TITLE
Fix crash when missing stop's local timezone

### DIFF
--- a/finders/dbfinder/finder.go
+++ b/finders/dbfinder/finder.go
@@ -155,6 +155,9 @@ func (f *Finder) FindFeedVersionServiceWindow(ctx context.Context, fvid int) (*m
 	if err != nil {
 		return nil, err
 	}
+	if a == nil {
+		return nil, errors.New("no service window found")
+	}
 	// Get local time
 	nowLocal := time.Now().In(a.Location)
 	if model.ForContext(ctx).Clock != nil {

--- a/finders/dbfinder/finder.go
+++ b/finders/dbfinder/finder.go
@@ -166,7 +166,6 @@ func (f *Finder) FindFeedVersionServiceWindow(ctx context.Context, fvid int) (*m
 		StartDate:    a.StartDate,
 		EndDate:      a.EndDate,
 		FallbackWeek: a.FallbackWeek,
-		Location:     a.Location,
 	}
 	return ret, err
 }

--- a/finders/dbfinder/finder.go
+++ b/finders/dbfinder/finder.go
@@ -152,10 +152,7 @@ func (f *Finder) RouteStopBuffer(ctx context.Context, param *model.RouteStopBuff
 
 func (f *Finder) FindFeedVersionServiceWindow(ctx context.Context, fvid int) (*model.ServiceWindow, error) {
 	a, _, err := f.fvslCache.Get(ctx, fvid)
-	if err != nil {
-		return nil, err
-	}
-	if a == nil {
+	if err != nil || a == nil || a.Location == nil {
 		return nil, errors.New("no service window found")
 	}
 	// Get local time

--- a/finders/dbfinder/stop_time_select.go
+++ b/finders/dbfinder/stop_time_select.go
@@ -236,12 +236,11 @@ func StopTimeFilterExpand(where *model.StopTimeFilter, fvsw *model.ServiceWindow
 
 	// Further processing of the StopTimeFilter
 	if where != nil {
-		var loc *time.Location
 		var nowLocal time.Time
 		if fvsw != nil {
-			loc = fvsw.Location
 			nowLocal = fvsw.NowLocal
 		}
+		loc := nowLocal.Location()
 
 		// Set ServiceDate to local timezone
 		// ServiceDate is a strict GTFS calendar date

--- a/finders/dbfinder/trip_select.go
+++ b/finders/dbfinder/trip_select.go
@@ -50,7 +50,7 @@ func TripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 				if dow < 0 {
 					dow = 6
 				}
-				where.ServiceDate = tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), fvsw.Location)
+				where.ServiceDate = tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), fvsw.NowLocal.Location())
 			}
 		}
 	}

--- a/finders/dbfinder/util.go
+++ b/finders/dbfinder/util.go
@@ -3,12 +3,12 @@ package dbfinder
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/tt"
 	"github.com/interline-io/transitland-server/model"
 )
@@ -35,6 +35,10 @@ func kebabize(a string) string {
 }
 
 func tzTruncate(s time.Time, loc *time.Location) *tt.Date {
+	if loc == nil {
+		log.Error().Msg("tzTruncate: loc is nil, set to UTC")
+		loc = time.UTC
+	}
 	return ptr(tt.NewDate(time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, loc)))
 }
 
@@ -60,11 +64,6 @@ func checkFloat(v *float64, min float64, max float64) float64 {
 		return max
 	}
 	return *v
-}
-
-func atoi(v string) int {
-	a, _ := strconv.Atoi(v)
-	return a
 }
 
 // unicode aware remove all non-alphanumeric characters

--- a/finders/rtfinder/lookup.go
+++ b/finders/rtfinder/lookup.go
@@ -105,19 +105,27 @@ func (f *lookupCache) StopTimezone(ctx context.Context, id int, known string) (*
 
 	// If a timezone is provided, save it and return immediately
 	if known != "" {
-		log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Msg("tz: using known timezone")
+		log.TraceCheck(func() {
+			log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Msg("tz: using known timezone")
+		})
 		return f.tzCache.Add(id, known)
 	}
 
 	// Check the cache
 	if loc, ok := f.tzCache.Get(id); ok {
-		log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Str("loc", loc.String()).Msg("tz: using cached timezone")
+		log.TraceCheck(func() {
+			log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Str("loc", loc.String()).Msg("tz: using cached timezone")
+		})
 		return loc, ok
 	} else {
-		log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Str("loc", loc.String()).Msg("tz: timezone not in cache")
+		log.TraceCheck(func() {
+			log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Str("loc", loc.String()).Msg("tz: timezone not in cache")
+		})
 	}
 	if id == 0 {
-		log.For(ctx).Trace().Int("stop_id", id).Msg("tz: lookup failed, cant find timezone for stops with id=0 unless speciifed explicitly")
+		log.TraceCheck(func() {
+			log.For(ctx).Trace().Int("stop_id", id).Msg("tz: lookup failed, cant find timezone for stops with id=0 unless speciifed explicitly")
+		})
 		return nil, false
 	}
 	// Otherwise lookup the timezone
@@ -139,7 +147,9 @@ func (f *lookupCache) StopTimezone(ctx context.Context, id int, known string) (*
 		return nil, false
 	}
 	loc, ok := f.tzCache.Add(id, tz)
-	log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Str("loc", loc.String()).Msg("tz: lookup successful")
+	log.TraceCheck(func() {
+		log.For(ctx).Trace().Int("stop_id", id).Str("known", known).Str("loc", loc.String()).Msg("tz: lookup successful")
+	})
 	return loc, ok
 }
 

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -1,6 +1,10 @@
 package clock
 
-import "time"
+import (
+	"time"
+
+	"github.com/interline-io/log"
+)
 
 // Allow for time mocking
 type Clock interface {
@@ -26,5 +30,9 @@ func (dc *Mock) Now() time.Time {
 // Helpers
 
 func tzTruncate(s time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		log.Error().Msg("tzTruncate: loc is nil, set to UTC")
+		loc = time.UTC
+	}
 	return time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, loc)
 }

--- a/internal/clock/swcache.go
+++ b/internal/clock/swcache.go
@@ -23,19 +23,19 @@ type ServiceWindow struct {
 type ServiceWindowCache struct {
 	db          sqlx.Ext
 	lock        sync.Mutex
-	fvslWindows map[int]ServiceWindow
+	fvslWindows map[int]*ServiceWindow
 	tzCache     *tzcache.Cache[int]
 }
 
 func NewServiceWindowCache(db sqlx.Ext) *ServiceWindowCache {
 	return &ServiceWindowCache{
 		db:          db,
-		fvslWindows: map[int]ServiceWindow{},
+		fvslWindows: map[int]*ServiceWindow{},
 		tzCache:     tzcache.NewCache[int](),
 	}
 }
 
-func (f *ServiceWindowCache) Get(ctx context.Context, fvid int) (ServiceWindow, bool, error) {
+func (f *ServiceWindowCache) Get(ctx context.Context, fvid int) (*ServiceWindow, bool, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	a, ok := f.fvslWindows[fvid]

--- a/internal/clock/swcache.go
+++ b/internal/clock/swcache.go
@@ -51,6 +51,8 @@ func (f *ServiceWindowCache) Get(ctx context.Context, fvid int) (*ServiceWindow,
 	if fvData.Location == nil {
 		return a, false, fmt.Errorf("unable to get cached default timezone for feed version %d", fvid)
 	}
+
+	a = &ServiceWindow{}
 	a.Location = fvData.Location
 
 	// Get fallback week from FVSL data

--- a/model/params.go
+++ b/model/params.go
@@ -14,7 +14,6 @@ type ServiceWindow struct {
 	StartDate    time.Time
 	EndDate      time.Time
 	FallbackWeek time.Time
-	Location     *time.Location
 }
 
 type StopPlaceParam struct {

--- a/server/gql/stop_time_resolver.go
+++ b/server/gql/stop_time_resolver.go
@@ -52,7 +52,7 @@ func (r *stopTimeResolver) Trip(ctx context.Context, obj *model.StopTime) (*mode
 func (r *stopTimeResolver) Arrival(ctx context.Context, obj *model.StopTime) (*model.StopTimeEvent, error) {
 	// Lookup timezone
 	loc, ok := model.ForContext(ctx).RTFinder.StopTimezone(ctx, obj.StopID.Int(), "")
-	if !ok {
+	if loc == nil || !ok {
 		return nil, errors.New("timezone not available for stop")
 	}
 	// Create arrival; fallback to RT departure if arrival is not present
@@ -73,7 +73,7 @@ func (r *stopTimeResolver) Arrival(ctx context.Context, obj *model.StopTime) (*m
 func (r *stopTimeResolver) Departure(ctx context.Context, obj *model.StopTime) (*model.StopTimeEvent, error) {
 	// Lookup timezone
 	loc, ok := model.ForContext(ctx).RTFinder.StopTimezone(ctx, obj.StopID.Int(), "")
-	if !ok {
+	if loc == nil || !ok {
 		return nil, errors.New("timezone not available for stop")
 	}
 	// Create departure; fallback to RT arrival if departure is not present


### PR DESCRIPTION
Fixes https://github.com/interline-io/tlv2/issues/109

```goroutine 231292 [running]:
github.com/graph-gophers/dataloader/v7.(*batcher[...]).batch.func1.1()
	/Users/irees/go/pkg/mod/github.com/graph-gophers/dataloader/v7@v7.1.0/dataloader.go:441 +0x93
panic({0x10ba6a0e0?, 0x10be95d30?})
	/Users/irees/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.darwin-amd64/src/runtime/panic.go:785 +0x132
time.Date(0xd?, 0x10b61e780?, 0x0?, 0x10bec0d01?, 0xc00657ca10?, 0x19?, 0x10b5c96f7?, 0x12?)
	/Users/irees/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.darwin-amd64/src/time/time.go:1518 +0x4c5
github.com/interline-io/transitland-server/internal/clock.tzTruncate({0x0?, 0x0?, 0x0?}, 0x0)
	/Users/irees/src/interline-io/transitland-server/internal/clock/clock.go:29 +0x96
github.com/interline-io/transitland-server/internal/clock.(*ServiceWindowCache).Get(0xc00061a0f0, {0x10beb3a88, 0xc0016e3110}, 0x69d62)
	/Users/irees/src/interline-io/transitland-server/internal/clock/swcache.go:58 +0x2fb
github.com/interline-io/transitland-server/finders/dbfinder.(*Finder).FindFeedVersionServiceWindow(0x10a4f3da8?, {0x10beb3a88, 0xc0016e3110}, 0x10a0bd4fd?)
	/Users/irees/src/interline-io/transitland-server/finders/dbfinder/finder.go:154 +0x5f
github.com/interline-io/transitland-server/finders/dbfinder.(*Finder).StopTimesByStopID.func2({0xc001961400, 0xd, 0x10}, {0xa6?, 0xc00131d300?}, 0xc000ebee00?)
	/Users/irees/src/interline-io/transitland-server/finders/dbfinder/finder.go:710 +0x71
github.com/interline-io/transitland-server/finders/dbfinder.paramGroupQuery[...]({0xc0003f7008, 0x64, 0x99}, 0x10be8e440?, 0xc000057c60, 0x10be8e448)
	/Users/irees/src/interline-io/transitland-server/finders/dbfinder/finder.go:1849 +0x5fc
github.com/interline-io/transitland-server/finders/dbfinder.(*Finder).StopTimesByStopID(0x10a07213c?, {0x10beb3a88?, 0xc0016e3110?}, {0xc0003f7008?, 0xc00115a508?, 0x10a064a6b?})
	/Users/irees/src/interline-io/transitland-server/finders/dbfinder/finder.go:702 +0x65
github.com/interline-io/transitland-server/server/gql.withWaitAndCapacity[...].func1({0xc0003f7008?, 0x64?, 0x10?})
	/Users/irees/src/interline-io/transitland-server/server/gql/loaders.go:199 +0x53
github.com/graph-gophers/dataloader/v7.(*batcher[...]).batch.func1(0x10beb3a88?, 0xc000057ec8?, {0x10beb3a88, 0xc0016e3110?}, {0xc0003f7008?, 0x10be9f600?, 0x10cdf77a0?}, 0xc001a65b00?)
	/Users/irees/go/pkg/mod/github.com/graph-gophers/dataloader/v7@v7.1.0/dataloader.go:445 +0x7e
github.com/graph-gophers/dataloader/v7.(*batcher[...]).batch(0x10bec84c0, {0x10beb3a88, 0xc0016e3110})
	/Users/irees/go/pkg/mod/github.com/graph-gophers/dataloader/v7@v7.1.0/dataloader.go:446 +0x389
created by github.com/graph-gophers/dataloader/v7.(*Loader[...]).Load in goroutine 231125
	/Users/irees/go/pkg/mod/github.com/graph-gophers/dataloader/v7@v7.1.0/dataloader.go:254 +0x571```
